### PR TITLE
Feat: Add customer dashboard with table and edit modal

### DIFF
--- a/src/crm/components/CustomersTable.tsx
+++ b/src/crm/components/CustomersTable.tsx
@@ -1,0 +1,238 @@
+import * as React from "react";
+import Box from "@mui/material/Box";
+import Card from "@mui/material/Card";
+import CardContent from "@mui/material/CardContent";
+import Table from "@mui/material/Table";
+import TableBody from "@mui/material/TableBody";
+import TableCell from "@mui/material/TableCell";
+import TableContainer from "@mui/material/TableContainer";
+import TableHead from "@mui/material/TableHead";
+import TableRow from "@mui/material/TableRow";
+import TablePagination from "@mui/material/TablePagination";
+import Typography from "@mui/material/Typography";
+import Stack from "@mui/material/Stack";
+import Avatar from "@mui/material/Avatar";
+import IconButton from "@mui/material/IconButton";
+import TextField from "@mui/material/TextField";
+import InputAdornment from "@mui/material/InputAdornment";
+import CircularProgress from "@mui/material/CircularProgress";
+import Alert from "@mui/material/Alert";
+import EditRoundedIcon from "@mui/icons-material/EditRounded";
+import SearchRoundedIcon from "@mui/icons-material/SearchRounded";
+
+interface User {
+  login: {
+    uuid: string;
+    username: string;
+  };
+  name: {
+    first: string;
+    last: string;
+  };
+  email: string;
+  picture: {
+    thumbnail: string;
+  };
+  location: {
+    city: string;
+    country: string;
+  };
+  phone: string;
+}
+
+interface CustomersTableProps {
+  onEditUser: (user: User) => void;
+}
+
+export default function CustomersTable({ onEditUser }: CustomersTableProps) {
+  const [users, setUsers] = React.useState<User[]>([]);
+  const [loading, setLoading] = React.useState(true);
+  const [error, setError] = React.useState<string | null>(null);
+  const [page, setPage] = React.useState(0);
+  const [rowsPerPage, setRowsPerPage] = React.useState(10);
+  const [searchTerm, setSearchTerm] = React.useState("");
+  const [totalUsers, setTotalUsers] = React.useState(0);
+
+  const fetchUsers = React.useCallback(
+    async (pageNum: number, searchQuery: string) => {
+      try {
+        setLoading(true);
+        setError(null);
+        const params = new URLSearchParams({
+          page: (pageNum + 1).toString(),
+          perPage: rowsPerPage.toString(),
+          ...(searchQuery && { search: searchQuery }),
+        });
+
+        const response = await fetch(
+          `https://user-api.builder-io.workers.dev/api/users?${params}`
+        );
+
+        if (!response.ok) {
+          throw new Error("Failed to fetch users");
+        }
+
+        const data = await response.json();
+        setUsers(data.data || []);
+        setTotalUsers(data.total || 0);
+      } catch (err) {
+        setError(
+          err instanceof Error ? err.message : "An error occurred while fetching users"
+        );
+        setUsers([]);
+      } finally {
+        setLoading(false);
+      }
+    },
+    [rowsPerPage]
+  );
+
+  React.useEffect(() => {
+    const debounceTimer = setTimeout(() => {
+      setPage(0);
+      fetchUsers(0, searchTerm);
+    }, 300);
+
+    return () => clearTimeout(debounceTimer);
+  }, [searchTerm, fetchUsers]);
+
+  React.useEffect(() => {
+    fetchUsers(page, searchTerm);
+  }, [page, rowsPerPage, fetchUsers]);
+
+  const handleChangePage = (_event: unknown, newPage: number) => {
+    setPage(newPage);
+  };
+
+  const handleChangeRowsPerPage = (
+    event: React.ChangeEvent<HTMLInputElement>
+  ) => {
+    setRowsPerPage(parseInt(event.target.value, 10));
+    setPage(0);
+  };
+
+  const getInitials = (firstName: string, lastName: string) => {
+    return `${firstName.charAt(0)}${lastName.charAt(0)}`.toUpperCase();
+  };
+
+  return (
+    <Card
+      variant="outlined"
+      sx={{
+        height: "100%",
+        display: "flex",
+        flexDirection: "column",
+      }}
+    >
+      <CardContent sx={{ pb: 0 }}>
+        <Stack spacing={2} sx={{ mb: 2 }}>
+          <Typography variant="h6" component="h3">
+            Customers
+          </Typography>
+          <TextField
+            placeholder="Search customers by name, email, or city..."
+            size="small"
+            variant="outlined"
+            value={searchTerm}
+            onChange={(e) => setSearchTerm(e.target.value)}
+            slotProps={{
+              input: {
+                startAdornment: (
+                  <InputAdornment position="start">
+                    <SearchRoundedIcon sx={{ color: "action.active" }} />
+                  </InputAdornment>
+                ),
+              },
+            }}
+            sx={{ width: "100%" }}
+          />
+        </Stack>
+      </CardContent>
+
+      {error && (
+        <Box sx={{ px: 2 }}>
+          <Alert severity="error">{error}</Alert>
+        </Box>
+      )}
+
+      {loading && users.length === 0 ? (
+        <Box
+          sx={{
+            display: "flex",
+            justifyContent: "center",
+            alignItems: "center",
+            minHeight: 300,
+          }}
+        >
+          <CircularProgress />
+        </Box>
+      ) : (
+        <>
+          <TableContainer sx={{ flexGrow: 1 }}>
+            <Table size="small" aria-label="customers table">
+              <TableHead>
+                <TableRow>
+                  <TableCell>Name</TableCell>
+                  <TableCell>Email</TableCell>
+                  <TableCell>Location</TableCell>
+                  <TableCell>Phone</TableCell>
+                  <TableCell align="right">Actions</TableCell>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {users.length === 0 ? (
+                  <TableRow>
+                    <TableCell colSpan={5} align="center" sx={{ py: 3 }}>
+                      <Typography color="textSecondary">
+                        No customers found
+                      </Typography>
+                    </TableCell>
+                  </TableRow>
+                ) : (
+                  users.map((user) => (
+                    <TableRow key={user.login.uuid} hover>
+                      <TableCell sx={{ fontWeight: 500 }}>
+                        <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+                          <Avatar
+                            src={user.picture.thumbnail}
+                            sx={{ width: 32, height: 32 }}
+                          >
+                            {getInitials(user.name.first, user.name.last)}
+                          </Avatar>
+                          {user.name.first} {user.name.last}
+                        </Box>
+                      </TableCell>
+                      <TableCell>{user.email}</TableCell>
+                      <TableCell>
+                        {user.location.city}, {user.location.country}
+                      </TableCell>
+                      <TableCell>{user.phone}</TableCell>
+                      <TableCell align="right">
+                        <IconButton
+                          size="small"
+                          aria-label="edit user"
+                          onClick={() => onEditUser(user)}
+                        >
+                          <EditRoundedIcon fontSize="small" />
+                        </IconButton>
+                      </TableCell>
+                    </TableRow>
+                  ))
+                )}
+              </TableBody>
+            </Table>
+          </TableContainer>
+          <TablePagination
+            rowsPerPageOptions={[10, 25, 50]}
+            component="div"
+            count={totalUsers}
+            rowsPerPage={rowsPerPage}
+            page={page}
+            onPageChange={handleChangePage}
+            onRowsPerPageChange={handleChangeRowsPerPage}
+          />
+        </>
+      )}
+    </Card>
+  );
+}

--- a/src/crm/components/UserEditModal.tsx
+++ b/src/crm/components/UserEditModal.tsx
@@ -1,0 +1,242 @@
+import * as React from "react";
+import Dialog from "@mui/material/Dialog";
+import DialogTitle from "@mui/material/DialogTitle";
+import DialogContent from "@mui/material/DialogContent";
+import DialogActions from "@mui/material/DialogActions";
+import TextField from "@mui/material/TextField";
+import Button from "@mui/material/Button";
+import Stack from "@mui/material/Stack";
+import Grid from "@mui/material/Grid";
+import CircularProgress from "@mui/material/CircularProgress";
+import Alert from "@mui/material/Alert";
+import Avatar from "@mui/material/Avatar";
+import Box from "@mui/material/Box";
+
+interface User {
+  login: {
+    uuid: string;
+    username: string;
+  };
+  name: {
+    first: string;
+    last: string;
+  };
+  email: string;
+  picture: {
+    thumbnail: string;
+  };
+  location: {
+    city: string;
+    country: string;
+    state: string;
+    postcode: string;
+    street: {
+      number: number;
+      name: string;
+    };
+  };
+  phone: string;
+  cell: string;
+  gender: string;
+}
+
+interface UserEditModalProps {
+  open: boolean;
+  user: User | null;
+  onClose: () => void;
+  onSave: (user: User) => Promise<void>;
+}
+
+export default function UserEditModal({
+  open,
+  user,
+  onClose,
+  onSave,
+}: UserEditModalProps) {
+  const [formData, setFormData] = React.useState<User | null>(null);
+  const [loading, setLoading] = React.useState(false);
+  const [error, setError] = React.useState<string | null>(null);
+
+  React.useEffect(() => {
+    if (user) {
+      setFormData(JSON.parse(JSON.stringify(user)));
+      setError(null);
+    }
+  }, [user, open]);
+
+  const handleChange = (field: string, value: string) => {
+    if (!formData) return;
+
+    const fieldParts = field.split(".");
+    const updatedData = JSON.parse(JSON.stringify(formData));
+
+    let current = updatedData;
+    for (let i = 0; i < fieldParts.length - 1; i++) {
+      current = current[fieldParts[i]];
+    }
+    current[fieldParts[fieldParts.length - 1]] = value;
+
+    setFormData(updatedData);
+  };
+
+  const handleSave = async () => {
+    if (!formData) return;
+
+    try {
+      setLoading(true);
+      setError(null);
+      await onSave(formData);
+      onClose();
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : "An error occurred while saving"
+      );
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  if (!formData) return null;
+
+  const getInitials = (firstName: string, lastName: string) => {
+    return `${firstName.charAt(0)}${lastName.charAt(0)}`.toUpperCase();
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
+      <DialogTitle>Edit Customer</DialogTitle>
+      <DialogContent>
+        <Stack spacing={3} sx={{ mt: 2 }}>
+          {error && <Alert severity="error">{error}</Alert>}
+
+          <Box sx={{ display: "flex", justifyContent: "center" }}>
+            <Avatar
+              src={formData.picture.thumbnail}
+              sx={{ width: 80, height: 80 }}
+            >
+              {getInitials(formData.name.first, formData.name.last)}
+            </Avatar>
+          </Box>
+
+          <Grid container spacing={2}>
+            <Grid item xs={12} sm={6}>
+              <TextField
+                fullWidth
+                label="First Name"
+                value={formData.name.first}
+                onChange={(e) => handleChange("name.first", e.target.value)}
+                size="small"
+              />
+            </Grid>
+            <Grid item xs={12} sm={6}>
+              <TextField
+                fullWidth
+                label="Last Name"
+                value={formData.name.last}
+                onChange={(e) => handleChange("name.last", e.target.value)}
+                size="small"
+              />
+            </Grid>
+            <Grid item xs={12}>
+              <TextField
+                fullWidth
+                label="Email"
+                type="email"
+                value={formData.email}
+                onChange={(e) => handleChange("email", e.target.value)}
+                size="small"
+              />
+            </Grid>
+            <Grid item xs={12} sm={6}>
+              <TextField
+                fullWidth
+                label="Phone"
+                value={formData.phone}
+                onChange={(e) => handleChange("phone", e.target.value)}
+                size="small"
+              />
+            </Grid>
+            <Grid item xs={12} sm={6}>
+              <TextField
+                fullWidth
+                label="Cell"
+                value={formData.cell}
+                onChange={(e) => handleChange("cell", e.target.value)}
+                size="small"
+              />
+            </Grid>
+            <Grid item xs={12}>
+              <TextField
+                fullWidth
+                label="Street"
+                value={formData.location.street.name}
+                onChange={(e) =>
+                  handleChange("location.street.name", e.target.value)
+                }
+                size="small"
+              />
+            </Grid>
+            <Grid item xs={12} sm={6}>
+              <TextField
+                fullWidth
+                label="City"
+                value={formData.location.city}
+                onChange={(e) => handleChange("location.city", e.target.value)}
+                size="small"
+              />
+            </Grid>
+            <Grid item xs={12} sm={6}>
+              <TextField
+                fullWidth
+                label="State"
+                value={formData.location.state}
+                onChange={(e) => handleChange("location.state", e.target.value)}
+                size="small"
+              />
+            </Grid>
+            <Grid item xs={12} sm={6}>
+              <TextField
+                fullWidth
+                label="Country"
+                value={formData.location.country}
+                onChange={(e) =>
+                  handleChange("location.country", e.target.value)
+                }
+                size="small"
+              />
+            </Grid>
+            <Grid item xs={12} sm={6}>
+              <TextField
+                fullWidth
+                label="Postal Code"
+                value={formData.location.postcode}
+                onChange={(e) =>
+                  handleChange("location.postcode", e.target.value)
+                }
+                size="small"
+              />
+            </Grid>
+          </Grid>
+        </Stack>
+      </DialogContent>
+      <DialogActions sx={{ p: 2 }}>
+        <Button onClick={onClose} disabled={loading}>
+          Cancel
+        </Button>
+        <Button
+          onClick={handleSave}
+          variant="contained"
+          disabled={loading}
+          sx={{
+            display: "flex",
+            alignItems: "center",
+            gap: 1,
+          }}
+        >
+          {loading && <CircularProgress size={20} />}
+          Save
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/src/crm/pages/Customers.tsx
+++ b/src/crm/pages/Customers.tsx
@@ -1,17 +1,87 @@
 import * as React from "react";
 import Box from "@mui/material/Box";
-import Typography from "@mui/material/Typography";
+import CustomersTable from "../components/CustomersTable";
+import UserEditModal from "../components/UserEditModal";
+
+interface User {
+  login: {
+    uuid: string;
+    username: string;
+  };
+  name: {
+    first: string;
+    last: string;
+  };
+  email: string;
+  picture: {
+    thumbnail: string;
+  };
+  location: {
+    city: string;
+    country: string;
+    state: string;
+    postcode: string;
+    street: {
+      number: number;
+      name: string;
+    };
+  };
+  phone: string;
+  cell: string;
+  gender: string;
+}
 
 export default function Customers() {
+  const [editingUser, setEditingUser] = React.useState<User | null>(null);
+  const [modalOpen, setModalOpen] = React.useState(false);
+
+  const handleEditUser = (user: User) => {
+    setEditingUser(user);
+    setModalOpen(true);
+  };
+
+  const handleCloseModal = () => {
+    setModalOpen(false);
+    setEditingUser(null);
+  };
+
+  const handleSaveUser = async (user: User) => {
+    try {
+      const response = await fetch(
+        `https://user-api.builder-io.workers.dev/api/users/${user.login.username}`,
+        {
+          method: "PUT",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            email: user.email,
+            name: user.name,
+            phone: user.phone,
+            cell: user.cell,
+            location: user.location,
+            gender: user.gender,
+          }),
+        }
+      );
+
+      if (!response.ok) {
+        throw new Error("Failed to update user");
+      }
+    } catch (error) {
+      throw error;
+    }
+  };
+
   return (
     <Box sx={{ width: "100%", maxWidth: { sm: "100%", md: "1700px" } }}>
-      <Typography variant="h4" component="h1" sx={{ mb: 4 }}>
-        Customers Page
-      </Typography>
-      <Typography paragraph>
-        This is the customers management page where you can view and manage your
-        customer data.
-      </Typography>
+      <CustomersTable onEditUser={handleEditUser} />
+      <UserEditModal
+        open={modalOpen}
+        user={editingUser}
+        onClose={handleCloseModal}
+        onSave={handleSaveUser}
+      />
     </Box>
   );
 }


### PR DESCRIPTION
**Purpose**

The user wants to add a dashboard to the Customers tab. This dashboard should be populated with data from the Users API and include a searchable table of customers. Additionally, the user requested the ability to edit individual users via a modal.

**Code changes**

*   **`CustomersTable.tsx`**: A new component that fetches and displays a list of customers in a table. It includes features like search, pagination, and an edit button for each customer.
*   **`UserEditModal.tsx`**: A new modal component that allows for editing the details of a selected user. It includes form fields for various user attributes and handles the save operation.
*   **`Customers.tsx`**: The main page for the customers tab has been updated to integrate the `CustomersTable` and `UserEditModal`. It now manages the state for the user editing flow.

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

🔗 [Edit in Builder.io](https://builder.io/app/projects/d3ca09c0183f459092fb8de9c6af7677/mystic-works-1)

👀 [Preview Link](https://d3ca09c0183f459092fb8de9c6af7677-mystic-works-1.projects.builder.my/)To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 8`



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>d3ca09c0183f459092fb8de9c6af7677</projectId>-->
<!--<branchName>mystic-works-1</branchName>-->